### PR TITLE
Fix typos in async comments

### DIFF
--- a/Backend/Steamlyzer/tests/test_games.py
+++ b/Backend/Steamlyzer/tests/test_games.py
@@ -7,7 +7,7 @@ import json
 
 #-----------------------------------TESTES DE FETCH_GAME_GENRES---------------------------------------------------------
 
-@pytest.mark.asyncio # Marcador que indica que a função é assicrona
+@pytest.mark.asyncio # Marcador que indica que a função é assíncrona
 async def test_fetch_game_genres():
   """Testa a funcao fetch_game_genres"""
   game = {'appid': 730}

--- a/Backend/Steamlyzer/tests/test_profile.py
+++ b/Backend/Steamlyzer/tests/test_profile.py
@@ -5,7 +5,7 @@ from Steamlyzer.services import profile
 import aiohttp
 import asyncio
 
-@pytest.mark.asyncio # Marcador que indica que a função é assicrona
+@pytest.mark.asyncio # Marcador que indica que a função é assíncrona
 async def test_fetch_user_profile():
   """Testa a funcao fetch_user_profile"""
   steam_id = "123456789"
@@ -29,7 +29,7 @@ async def test_fetch_user_profile():
       assert "players" in result["response"]
 
 
-@pytest.mark.asyncio # Marcador que indica que a função é assicrona
+@pytest.mark.asyncio # Marcador que indica que a função é assíncrona
 async def test_fetch_user_profile_private():
   """Testa a funcao fetch_user_profile"""
   steam_id = "123456789"


### PR DESCRIPTION
## Summary
- fix typo in games tests async comment
- fix typo in profile tests async comments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_683f41f5e3648325b542d3e92193b9e9