### PR TITLE
Patch fetch genres retry test

### DIFF
--- a/Backend/Steamlyzer/tests/test_games.py
+++ b/Backend/Steamlyzer/tests/test_games.py
@@ -50,7 +50,8 @@ async def test_fetch_game_genres_api_error():
     # Espera-se que a função retorne valores vazios
     expected_result = {'categories': '', 'genres': ''}
 
-    with patch("aiohttp.ClientSession.get", return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))):
+    with patch("Steamlyzer.services.games.make_request_with_retry", return_value=None), \
+         patch("aiohttp.ClientSession.get", return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))):
         async with aiohttp.ClientSession() as session:
             result = await games.fetch_game_genres(session, game)
             assert result == expected_result


### PR DESCRIPTION
## Summary
- ensure `fetch_game_genres` test uses patched retry helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_683f41fe5b7483259c8341854d15d6d1