### PR TITLE
Fix README setup instructions for Backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ git clone https://github.com/seu-usuario/steamlyzer-api.git
 cd steamlyzer-api
 python -m venv venv
 source venv/bin/activate  # no Windows use venv\Scripts\activate
+cd Backend
 pip install -r requirements.txt
 python manage.py runserver
 ```

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -56,6 +56,7 @@ git clone https://github.com/your-user/steamlyzer-api.git
 cd steamlyzer-api
 python -m venv venv
 source venv/bin/activate  # On Windows use venv\Scripts\activate
+cd Backend
 pip install -r requirements.txt
 python manage.py runserver
 ```


### PR DESCRIPTION
## Summary
- show `cd Backend` in root README setup example
- mention `cd Backend` in English docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683f41d98da08325bcbc3933b6e40c26